### PR TITLE
readme: add last usable martin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ docker-compose up
 ```
 
 Open `localhost:3000` in your browser
+
+# Requirements
+
+Frontend requires [martin v0.6.2](https://github.com/maplibre/martin/tree/v0.6.2)


### PR DESCRIPTION
Last version to support this frontend is [martin v0.6.2](https://github.com/maplibre/martin/tree/v0.6.2)
After that /rpc target is missing.